### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/DIGI-EDGE/DPE-TRAM-GEN
 https://github.com/kaiaai/micro_ros_arduino_kaia
 https://github.com/MrYsLab/Telemetrix4UnoR4
 https://github.com/Reefwing-Software/Reefwing-MPU6050


### PR DESCRIPTION
Hello Arduino team and fellow developers,

I wanted to inform you all that I've updated the URL for the Digiedge library in my project. Previously, I was using the URL "https://github.com/HoussamElbiade/Digiedge_frame_generator" for the library. However, I have now switched to using the official repository URL: "https://github.com/DIGI-EDGE/DPE-TRAM-GEN". This change ensures that I'm utilizing the most up-to-date and authoritative source for the Digiedge library.

I want to express my appreciation to the maintainers of the Digiedge library for their hard work in providing such a valuable resource. I believe this transition will help keep my project aligned with the latest advancements and improvements in the library.

Thank you,
Houssame ELBIADE, Digieye
